### PR TITLE
Added batch albumID processing via ; delimiter

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -15,9 +15,9 @@
     <form hx-post="/api/task/add" hx-target="#tasks" {{/* hx-swap="beforeend" */}}
         hx-on::after-request='if(event.detail.successful) {this.AlbumID.value = ""} else {window.alert(event.detail.xhr.responseText); this.reset()}'
         hx-swap="focus-scroll:true">
-        <input name="AlbumID" value="" placeholder="Insert the albumID here" required>
+        <input name="AlbumID" value="" placeholder="Insert albumIDs here" required>
 
-        <label for="ServiceNumber">Select a service to download from:</label>
+        <label for="ServiceNumber">(separated by ;)    Select a service to download from:</label>
         <select id="ServiceNumber" name="ServiceNumber">
             <option value="0">Doujinstyle</option>
             <option value="1">SukiDesuOst</option>


### PR DESCRIPTION
First, let me say this is actually my first organic pull request and I apologize in advance if I did anything wrong in the process. 

Next, let me say how grateful I am to you for your work. I was already well underway on a puppeteer script to automate manually clicking those download buttons just to scrape the links from the mediafire redirects, but your solution is so much more elegant. 
Once I saw that your downloader worked on IDs, I just retooled my wip pupeteer code to scrape ids. I had already spent this much time avoiding monotonous repetition, so there was no way I was going to manually add my list of ids one by one, hence this pull request.